### PR TITLE
Tracks

### DIFF
--- a/opv_api_client/ressource.py
+++ b/opv_api_client/ressource.py
@@ -16,6 +16,9 @@ class Ressource(PropertyAsDict, metaclass=MetaRessource):
     # Initializers
     ###
 
+    def __hash__(self):
+        return hash(frozenset(self.id.items()))
+
     def __init__(self, rest_client, ids=None, lazy=False):
         """Warning, __init__ should be called at the very end of child's init - Won't works otherwise
 

--- a/opv_api_client/ressources/__init__.py
+++ b/opv_api_client/ressources/__init__.py
@@ -4,5 +4,6 @@ from opv_api_client.ressources.cp import Cp
 from opv_api_client.ressources.panorama import Panorama
 from opv_api_client.ressources.tile import Tile
 from opv_api_client.ressources.sensors import Sensors
+from opv_api_client.ressources.trackedge import TrackEdge
 
-__all__ = ["Lot", "Campaign", "Cp", "Panorama", "Tile", "Sensors"]
+__all__ = ["Lot", "Campaign", "Cp", "Panorama", "Tile", "Sensors", "TrackEdge"]

--- a/opv_api_client/ressources/panorama.py
+++ b/opv_api_client/ressources/panorama.py
@@ -11,3 +11,4 @@ class Panorama(Ressource):
     class _rel:
         tiles = Relationship(RessourceProxy("tile"), many=True)
         cp = Relationship(RessourceProxy("cp"))
+        track_edges = Relationship(RessourceProxy('trackedge'), many=True)

--- a/opv_api_client/ressources/trackedge.py
+++ b/opv_api_client/ressources/trackedge.py
@@ -9,5 +9,5 @@ class TrackEdge(Ressource):
     _primary_keys = ("id_track_edge", "id_malette")
 
     class _rel:
-        panorama_to = Relationship(RessourceProxy("panorama"))
-        panorama_from = Relationship(RessourceProxy("panorama"))
+        lot_to = Relationship(RessourceProxy("lot"))
+        lot_from = Relationship(RessourceProxy("lot"))

--- a/opv_api_client/ressources/trackedge.py
+++ b/opv_api_client/ressources/trackedge.py
@@ -1,0 +1,13 @@
+from opv_api_client.ressource import Ressource
+from opv_api_client.ressource_list import RessourceProxy, register
+from opv_api_client.relationship import Relationship
+
+@register
+class TrackEdge(Ressource):
+    _api_version = "v1"
+    _name = "trackedge"
+    _primary_keys = ("id_track_edge", "id_malette")
+
+    class _rel:
+        panorama_to = Relationship(RessourceProxy("panorama"))
+        panorama_from = Relationship(RessourceProxy("panorama"))


### PR DESCRIPTION
Adding track to client with correct relationship.

A track is linking 2 lot.

To create a track between 2 lot :
```python
# coding: utf-8

from opv_api_client import ressources, Filter, RestClient

c = RestClient("http://opv_master:5000")
l1 = c.make(ressources.Lot, 1, 15)
l2 = c.make(ressources.Lot, 2, 15)
te = c.make(ressources.TrackEdge)
te.id_malette = 15
te.lot_from = l1
te.lot_to = l2
te.pitch = 0
te.yaw = 0
te.targetPitch = 30
te.targetYaw = 0

te.create()
```